### PR TITLE
fix warning

### DIFF
--- a/lib/Text/TestBase/Block.pm
+++ b/lib/Text/TestBase/Block.pm
@@ -63,6 +63,7 @@ our $AUTOLOAD;
 sub AUTOLOAD {
     $AUTOLOAD =~ s/.*:://;
     my $self = shift;
+    return if $AUTOLOAD eq 'DESTROY';
     unless ($self->has_section($AUTOLOAD)) {
         Carp::croak("There is no $AUTOLOAD' sction in the block.");
     }

--- a/t/Text-TestBase/03_block.t
+++ b/t/Text-TestBase/03_block.t
@@ -14,16 +14,21 @@ xxx
 yyy
 ...
 
-my $block = Text::TestBase->new()->_make_block($hunk);
 subtest 'check' => sub {
-    is($block->get_section('input'), "xxx\n");
-    is($block->input, "xxx\n");
-    is($block->get_section('expected'), "yyy\n");
-    is($block->description, "hogehoge");
-    is($block->name, "hogehoge");
-    ok($block->has_section('ONLY'));
-    ok(not $block->has_section('SKIP'));
+    my $warnings = '';
+    local $SIG{__WARN__} = sub { $warnings .= $_[0] };
+    {
+        my $block = Text::TestBase->new()->_make_block($hunk);
+        is($block->get_section('input'), "xxx\n");
+        is($block->input, "xxx\n");
+        is($block->get_section('expected'), "yyy\n");
+        is($block->description, "hogehoge");
+        is($block->name, "hogehoge");
+        ok($block->has_section('ONLY'));
+        ok(not $block->has_section('SKIP'));
+        note Dumper($block);
+    }
+    is($warnings, '');
 };
-note Dumper($block);
 
 done_testing;


### PR DESCRIPTION
Following warnig is outputted when I run tests using Test::Base::Less.

```
    (in cleanup) There is no DESTROY' sction in the block. at /Library/Perl/Updates/5.12.3/Test/Builder.pm line 235.
```
