### PR TITLE
lines filter

### DIFF
--- a/lib/Test/Base/Less.pm
+++ b/lib/Test/Base/Less.pm
@@ -147,6 +147,14 @@ sub _trim {
     } @_;
 }
 
+Test::Base::Less::register_filter(lines => \&_lines);
+sub _lines {
+    my $src = shift;
+    return () unless length $src;
+    my @lines = ($src =~ /^(.*\n?)/gm);
+    return @lines;
+}
+
 1;
 __END__
 
@@ -224,6 +232,14 @@ C<uc()> the arguments.
 
 Remove extra blank lines from the beginning and end of the data. This
 allows you to visually separate your test data with blank lines.
+
+=back
+
+=item lines
+
+Break the data into an anonymous array of lines.
+Each line (except possibly the last one if the chomp filter came first)
+will have a newline at the end.
 
 =back
 

--- a/t/Test-Base-Less/default_filters.t
+++ b/t/Test-Base-Less/default_filters.t
@@ -5,15 +5,18 @@ use Test::Base::Less;
 
 filters {
     test_trim => [qw/trim/],
+    test_lines => [qw/lines/],
 };
 
-my ($block) = blocks();
-is($block->test_trim, $block->expected_trim);
+my (@blocks) = blocks();
+is($blocks[0]->test_trim, $blocks[0]->expected_trim, 'trim');
+
+is_deeply([$blocks[1]->test_lines], ["a\n","b\n","c\n",], 'lines');
 
 done_testing;
 __END__
 
-===
+=== trim
 --- test_trim
 
 xxx
@@ -22,3 +25,8 @@ xxx
 --- expected_trim
 xxx
 --- test_
+=== lines
+--- test_lines
+a
+b
+c


### PR DESCRIPTION
Add a default filter for returning a data section as an array of
lines. This is the most common filter for me to use. The code
is basically copied from Test::Base, so it should be compatible
with code that used that.
