### PR TITLE
add simple block filter

### DIFF
--- a/lib/Data/Section/TestBase.pm
+++ b/lib/Data/Section/TestBase.pm
@@ -15,8 +15,9 @@ sub new {
     bless { %args }, $class;
 }
 
-sub blocks() {
+sub blocks(;$) {
     my $self = ref $_[0] ? shift : __PACKAGE__->new(package => scalar caller);
+    my $filter = shift;
 
     my $d = do { no strict 'refs'; \*{$self->{package}."::DATA"} };
     return unless defined fileno $d;
@@ -31,6 +32,9 @@ sub blocks() {
     my @blocks = $parser->parse($content);
     for my $block (@blocks) {
         $block->{_lineno} += $line_offset;
+    }
+    if($filter){
+        return grep {$_->has_section($filter)} @blocks;
     }
     return @blocks;
 }
@@ -56,9 +60,10 @@ This module parse a DATA section as Test::Base format by L<Text::TestBase>.
 
 =over 4
 
-=item my @blocks = blocks();
+=item my @blocks = blocks([section_name]);
 
-Get a list of blocks from DATA section Element of @list is a instance of Text::TestBase::Block.
+Get a list of blocks from the DATA section. The elements of @list are instances of L<Text::TestBase::Block>.
+If C<section_name> is provided, only return blocks that have a section with that name.
 
 =back
 

--- a/t/Data-Section-TestBase/04_data.t
+++ b/t/Data-Section-TestBase/04_data.t
@@ -6,25 +6,41 @@ use Data::Section::TestBase;
 
 my @blocks = blocks;
 
-is(0+@blocks, 2);
+is(0+@blocks, 3);
 
 subtest 'first block' => sub {
     my $b = $blocks[0];
     is($b->name, 'foo');
     is($b->get_section('input'), 'yyy');
     is($b->get_section('expected'), 'zzz');
-    is($b->get_lineno, 31, 'lineno');
+    is($b->get_lineno, 47, 'lineno');
 };
 
 subtest 'second block' => sub {
     my $b = $blocks[1];
     is($b->name, 'bar');
     is($b->get_section('input'), "xxx\n");
-    is($b->get_section('expected'), "ppp\n");
-    is($b->get_lineno, 35, 'lineno');
+    is($b->get_section('expected'), "ppp\n\n");
+    is($b->get_lineno, 51, 'lineno');
 };
 
+test_third_block($blocks[2], 'third block');
+
+@blocks = blocks('foo');
+is(0+blocks('foo'),  1);
+test_third_block($blocks[0], 'first filtered block');
+
 done_testing;
+
+sub test_third_block {
+    my ($b, $name) = @_;
+    subtest $name => sub {
+        is($b->name, 'baz');
+        is($b->get_section('foo'), "vvv");
+        is($b->get_section('bar'), "www");
+        is($b->get_lineno, 57, 'lineno');
+    };
+}
 
 __DATA__
 
@@ -37,3 +53,7 @@ __DATA__
 xxx
 --- expected
 ppp
+
+=== baz
+--- foo : vvv
+--- bar: www


### PR DESCRIPTION
Allow the caller to get only blocks containing a given named section.
This is consistent with Test::Base.